### PR TITLE
IBX-7057: Provided Notifications API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "eslint-config-ibexa/eslint"
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,9 @@
-| Question                       | Answer                                                |
-|--------------------------------|-------------------------------------------------------|
-| **JIRA issue**                 | [IBX-XXXXX](https://issues.ibexa.co/browse/IBX-XXXXX) |
-| **Type**                       | feature/bug/improvement                               |
-| **Target eZ Platform version** | `v4.6`                |
-| **BC breaks**                  | yes/no                                                |
-| **Doc needed**                 | yes/no                                                |
+| Question                 | Answer                                              |
+|--------------------------|-----------------------------------------------------|
+| **JIRA issue**           | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX) |
+| **Type**                 | feature/bug/improvement                             |
+| **Target Ibexa version** | `v4.6`                                              |
+| **BC breaks**            | yes/no                                              |
 
 <!-- Replace this comment with Pull Request description -->
 
@@ -12,5 +11,6 @@
 - [ ] Provided PR description.
 - [ ] Tested the solution manually.
 - [ ] Provided automated test coverage.
-- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
-- [ ] Asked for a review (ping `@ibexa/engineering`).
+- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
+- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
+- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 |--------------------------------|-------------------------------------------------------|
 | **JIRA issue**                 | [IBX-XXXXX](https://issues.ibexa.co/browse/IBX-XXXXX) |
 | **Type**                       | feature/bug/improvement                               |
-| **Target eZ Platform version** | `v4.x` - please update `x` accordingly                |
+| **Target eZ Platform version** | `v4.6`                |
 | **BC breaks**                  | yes/no                                                |
 | **Doc needed**                 | yes/no                                                |
 

--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -1,0 +1,220 @@
+name: Backend build
+
+on:
+    push:
+        branches:
+            - main
+            - '[0-9]+.[0-9]+'
+    pull_request: ~
+
+jobs:
+    cs-fix:
+        name: Run code style check
+        runs-on: "ubuntu-22.04"
+        strategy:
+            matrix:
+                php:
+                    - '8.1'
+        steps:
+            -   uses: actions/checkout@v3
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: 'pdo_sqlite, gd'
+                    tools: cs2pr
+
+            -   name: Add composer keys for private packagist
+                run: |
+                    composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
+                    composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
+                env:
+                    SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+                    SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+                    TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+
+            -   uses: ramsey/composer-install@v2
+                with:
+                    dependency-versions: "highest"
+
+            -   name: Run code style check
+                run: composer run-script check-cs -- --format=checkstyle | cs2pr
+
+    deptrac:
+        name: Deptrac
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+            -   name: Deptrac
+                uses: smoench/deptrac-action@master
+
+    tests:
+        name: Tests
+        runs-on: "ubuntu-22.04"
+        timeout-minutes: 10
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php:
+                    - '7.4'
+                    - '8.1'
+                    - '8.2'
+
+        steps:
+            -   uses: actions/checkout@v3
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: pdo_sqlite, gd
+                    tools: cs2pr
+
+            -   name: Add composer keys for private packagist
+                run: |
+                    composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
+                    composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
+                env:
+                    SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+                    SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+                    TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+
+            -   uses: ramsey/composer-install@v2
+                with:
+                    dependency-versions: "highest"
+                    composer-options: "--prefer-dist --no-progress --no-suggest"
+
+            -   name: Setup problem matchers for PHPUnit
+                run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Run PHPStan analysis
+                run: composer run-script phpstan
+
+            -   name: Run test suite
+                run: composer run-script --timeout=600 test
+
+    integration-tests-postgres:
+        name: PostgreSQL integration tests
+        needs: tests
+        services:
+            postgres:
+                image: postgres:10
+                ports:
+                    - 5432
+                env:
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: testdb
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+                    --tmpfs /var/lib/postgres
+        runs-on: "ubuntu-22.04"
+        timeout-minutes: 10
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php:
+                    - '7.4'
+                    - '8.1'
+                    - '8.2'
+
+        steps:
+            -   uses: actions/checkout@v3
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: pdo_pgsql, gd
+                    tools: cs2pr
+
+            -   name: Add composer keys for private packagist
+                run: |
+                    composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
+                    composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
+                env:
+                    SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+                    SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+                    TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+
+            -   uses: ramsey/composer-install@v2
+                with:
+                    dependency-versions: "highest"
+
+            -   name: Setup problem matchers for PHPUnit
+                run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Run integration test suite vs Postgresql
+                run: composer run-script --timeout=600 test -- --testsuite integration
+                env:
+                    DATABASE_URL: "pgsql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/testdb?server_version=10"
+
+    integration-tests-mysql:
+        name: MySQL integration tests
+        needs: tests
+        services:
+            mysql:
+                image: ghcr.io/ibexa/core/mysql
+                ports:
+                    - 3306/tcp
+                env:
+                    MYSQL_RANDOM_ROOT_PASSWORD: true
+                    MYSQL_USER: mysql
+                    MYSQL_PASSWORD: mysql
+                    MYSQL_DATABASE: testdb
+                options: >-
+                    --health-cmd="mysqladmin ping"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+                    --tmpfs=/var/lib/mysql
+        runs-on: "ubuntu-22.04"
+        timeout-minutes: 10
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php:
+                    - '7.4'
+                    - '8.1'
+                    - '8.2'
+
+        steps:
+            -   uses: actions/checkout@v3
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: pdo_mysql, gd, redis
+                    tools: cs2pr
+
+            -   name: Add composer keys for private packagist
+                run: |
+                    composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
+                    composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
+                env:
+                    SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+                    SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+                    TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+
+            -   uses: ramsey/composer-install@v2
+                with:
+                    dependency-versions: "highest"
+
+            -   name: Setup problem matchers for PHPUnit
+                run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Run integration test suite vs MySQL
+                run: composer run-script --timeout=600 test -- --testsuite integration
+                env:
+                    DATABASE_URL: "mysql://mysql:mysql@127.0.0.1:${{ job.services.mysql.ports[3306] }}/testdb"

--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -26,15 +26,6 @@ jobs:
                     extensions: 'pdo_sqlite, gd'
                     tools: cs2pr
 
-            -   name: Add composer keys for private packagist
-                run: |
-                    composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-                    composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
-                env:
-                    SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-                    SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-                    TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
-
             -   uses: ramsey/composer-install@v2
                 with:
                     dependency-versions: "highest"
@@ -73,15 +64,6 @@ jobs:
                     coverage: none
                     extensions: pdo_sqlite, gd
                     tools: cs2pr
-
-            -   name: Add composer keys for private packagist
-                run: |
-                    composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-                    composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
-                env:
-                    SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-                    SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-                    TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
 
             -   uses: ramsey/composer-install@v2
                 with:
@@ -136,15 +118,6 @@ jobs:
                     extensions: pdo_pgsql, gd
                     tools: cs2pr
 
-            -   name: Add composer keys for private packagist
-                run: |
-                    composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-                    composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
-                env:
-                    SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-                    SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-                    TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
-
             -   uses: ramsey/composer-install@v2
                 with:
                     dependency-versions: "highest"
@@ -197,15 +170,6 @@ jobs:
                     coverage: none
                     extensions: pdo_mysql, gd, redis
                     tools: cs2pr
-
-            -   name: Add composer keys for private packagist
-                run: |
-                    composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-                    composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
-                env:
-                    SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-                    SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-                    TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
 
             -   uses: ramsey/composer-install@v2
                 with:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -2,7 +2,7 @@
 name: PR check
 on:
   pull_request:
-    types: 
+    types:
       - opened
       - synchronize
       - reopened

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 name: Call Automatic Changelog Generator for tag Workflow
 
-on:  
+on:
   push:
     tags:
       - 'v*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.php-cs-fixer.cache
+/.phpunit.result.cache
+/composer.lock
+/node_modules/
+/vendor
+/yarn.lock
+/var

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+return \Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory::build()->setFinder(
+    PhpCsFixer\Finder::create()
+        ->in(__DIR__ . '/src')
+        ->in(__DIR__ . '/tests')
+        ->files()->name('*.php')
+);

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -3,7 +3,7 @@ Copyright (C) 1999-2023 Ibexa AS (formerly eZ Systems AS). All rights reserved.
 This source code is available separately under the following licenses:
 
 A - Ibexa Business Use License Agreement (Ibexa BUL),
-version 2.3 or later versions (as license terms may be updated from time to time)
+version 2.4 or later versions (as license terms may be updated from time to time)
 Ibexa BUL is granted by having a valid Ibexa DXP (formerly eZ Platform Enterprise) subscription,
 as described at: https://www.ibexa.co/product
 For the full Ibexa BUL license text, please see:
@@ -12,9 +12,7 @@ For the full Ibexa BUL license text, please see:
 
 AND
 
-B - Ibexa Trial and Test License Agreement (Ibexa TTL),
-version 2.2 or later versions (as license terms may be updated from time to time)
-Trial can be granted by Ibexa, reach out to Ibexa AS for evaluation access: https://www.ibexa.co/about-ibexa/contact-us
-For the full Ibexa TTL license text, please see:
+B - GNU General Public License, version 2
+Grants an copyleft open source license with ABSOLUTELY NO WARRANTY. For the full GPL license text, please see:
 - LICENSE file placed in the root of this source code, or
-- https://www.ibexa.co/software-information/licenses-and-agreements (latest version applies)
+- https://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 1999-2021 Ibexa AS (formerly eZ Systems AS). All rights reserved.
+Copyright (C) 1999-2023 Ibexa AS (formerly eZ Systems AS). All rights reserved.
 
 This source code is available separately under the following licenses:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,315 +1,360 @@
-Copyright (C) 1999-2023 Ibexa AS. All rights reserved.
-This source code is provided under the license bundled below.
+Copyright (C) 1999-2021 Ibexa AS (formerly eZ Systems AS). All rights reserved.
 
-The source code is available separately under the Ibexa BUL 2.3 License,
-granted by having a valid Ibexa Digital Experience Platform (DXP) subscription:
-- https://www.ibexa.co/products
-- https://www.ibexa.co/software-information/licenses-and-agreements/ibexa-business-use-license-agreement-ibexa-bul-version-2.3
+This source code is available separately under the following licenses:
 
-To get access to the full source code under TTL license below,
-reach out to Ibexa AS for evaluation access:
-- https://www.ibexa.co/about-ibexa/contact-us
+A - Ibexa Business Use License Agreement (Ibexa BUL),
+version 2.4 or later versions (as license terms may be updated from time to time)
+Ibexa BUL is granted by having a valid Ibexa DXP (formerly eZ Platform Enterprise) subscription,
+as described at: https://www.ibexa.co/product
+For the full Ibexa BUL license text, please see:
+- LICENSE-bul file placed in the root of this source code, or
+- https://www.ibexa.co/software-information/licenses-and-agreements (latest version applies)
+
+AND
+
+B - GNU General Public License, version 2
+Grants an copyleft open source license with ABSOLUTELY NO WARRANTY.
+Full GPL license text below, or online on: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+
 
 ----------------------------------------------------------
 
-Ibexa Trial and Test License Agreement ("Ibexa TTL") Version 2.2
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-IMPORTANT: Please read the following license agreement carefully.
+                            Preamble
 
-This license agreement is between Ibexa AS (Norwegian business
-registration no. 981 601 564), a Norwegian company ("Licensor" or "Ibexa"),
-and a test or trial user ("Licensee" or "you"). By installing all or any
-portion of the software (or authorizing any other person to do so), you
-accept the terms and conditions of this license. If you acquired the
-software without an opportunity to review this license and do not accept
-the license, you must: (a) not use the software and (b) return or delete
-the software, with your certification of deletion, within thirty (30)
-days of the acquire date.
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
 
-This license agreement is entered into in connection with Licensee's
-participation in testing a new version of Licensor software and is valid
-for 6 months from the date the software was acquired (downloaded).
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
 
-The parties hereby agree to the following software license terms:
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
 
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
 
-1. Definitions
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
 
-"Licensed Software" means the Ibexa Digital Experience Platform (DXP)
-or other software product (such as Ibexa Commerce) downloaded, ordered or
-otherwise legally acquired (licensed) by Licensee from Licensor (or
-other party authorized by the Licensor) under these terms.
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
 
-"Licensed Copy" means one sample of the Licensed Software.
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
 
-"Website" means up to three defined site access configurations (unique
-URLs) that may for instance consist of one site for public use, one site
-for internal use (such as an intranet) and one site for site
-administrator use, communicated an unlimited number of channels
-(such as traditional web, mobile).
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-2. License grant
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-2.1 You may
-Licensor grants you a limited, non-exclusive, time limited and
-non-transferable right to:
-(a) install and run the Licensed Copy on the agreed number of Websites
-for internal testing purposes;
-(b) make enhancements, patches, workarounds, bug fixes or other
-modifications (collectively "Licensee Modifications") to the Licensed
-Copy, solely for your internal testing of the Licensed Software, and
-(c) perform presentations based on the Licensed Software, including
-building and presenting sample solutions to your clients or potential
-clients.
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
 
-Since the license is free of charge, you are obliged to submit Licensee
-Modifications to Ibexa on a continuous basis to contribution@ibexa.co as
-contributions, see section 7.1. Such contribution must include a short
-note explaining the Licensee Modification.
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
 
-Licensee may make a reasonable number of copies of the Licensed Copy as
-required for backup and archival purposes only.
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
 
-2.2 You may not
-Licensee may use the Licensed Software only as expressly granted in
-section 2.1. Without limiting the foregoing, Licensee may not: (a) use
-or operate the Licensed Software for regular business use; (b) give,
-lease, license, sell, make available, or distribute any part of the
-Licensed Software or Licensee Modifications to any third party, except
-as otherwise expressly permitted herein; (c) use the Licensed Software
-to operate in or as a time-sharing, outsourcing, service bureau,
-application service provider, managed service provider environment or
-similar service directed towards and performed on behalf or for the
-benefit of a third party; (d) copy the Licensed Software onto any public
-or distributed network; or (e) change any rights notices which appear in
-the Licensed Software.
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
 
-3. Your responsibility
-Except as expressly set forth herein or in a separate written agreement,
-Licensee is the sole responsible for the installation of the Licensed
-Software, its operation, supervision, maintenance, management and
-related training and support. You are also the sole responsible for any
-related installation, maintenance and configuration of computer hardware
-used by the Licensed Software.
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
 
-4. Price
-You may use the Software free of charge.
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
 
-5. Audit rights
-During the term of this license and for a three (3) year period
-following its termination, Licensor may conduct periodic reviews of
-Licensee's records relating to its Licensed Software for the purpose of
-verifying Licensee's compliance with this license and any related
-agreements. During this three (3) year period, you are obliged to
-maintain complete and accurate books and other records related to
-software licensing and related payments. Licensor must exercise its
-right of audit upon no fewer than 15 days' prior notice. Licensee will
-provide Licensor with reasonable access and assistance for the audit,
-including reasonable use of available office equipment and space.
-Licensor shall upon request deliver to Licensee a copy of the results of
-any such audit.
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
 
-6. Termination
-Licensor may terminate this license immediately if you are in breach any
-of its provisions and such breach remains uncured 30 days after receipt
-of notice. In the event that you are or becomes liquidated, dissolved,
-bankrupt or insolvent, whether voluntarily or involuntarily, or is to
-take any action to be so declared, Licensor may terminate this license
-immediately. Upon cancellation or other termination of this license, for
-any reason, you must immediately destroy all copies of the Licensed
-Software, and confirm the destruction within  7 (seven) days. Sections 5
-through 11 shall survive the termination of this license for any reason.
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
 
-7. Intellectual property rights
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
 
-7.1 General
-Licensee agrees that the copyright and all other intellectual property
-and proprietary rights of whatever nature in the Licensed Software and
-related documentation are not by this license transferred to you. No
-trademarks of Ibexa may be used by you without Licensor's express written
-permission. If permission is grated, use must always take place in
-accordance with the applicable Licensor guidelines as they may be
-updated from time to time. For Licensee Modifications, you must, in the
-modified files and in a separate text file, clearly indicate that the
-Licensed Software contains modifications and state their dates.
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
 
-7.2 Contribution of Licensee Modifications
-To the extent that any contributed Licensee Modifications incorporates
-any element which is subject to any intellectual property right owned by
-Licensee, Licensee hereby grants to Ibexa an unrestricted, non-exclusive,
-perpetual, royalty-free, world-wide, irrevocable and fully transferable
-license to make, use, sell, offer for sale, reproduce, create
-derivatives of, publish, display, sublicense or otherwise practice such
-intellectual property right.
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
 
-Regarding any copyrights in Licensee Modifications:
-- You hereby assign to us joint ownership, and to the extent that such
-  assignment is or becomes invalid, ineffective or unenforceable, you
-  hereby grant to us a perpetual, irrevocable, non-exclusive, worldwide,
-  no-charge unrestricted license to exercise all rights under those
-  copyrights. This includes, at our option, the right to sublicense
-  these same rights to third parties through multiple levels of
-  sub-licensees or other licensing arrangements;
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
 
-- You agree that each of us can do all things in relation to Licensee
-  Modifications as if each of us were sole and independent copyright
-  holders. If one of us makes a derivative work the Licensee
-  Modifications, the one who makes the derivative work (or has it made)
-  will be the sole owner of that derivative work, hereunder make, have
-  made, use, license, offer to license, import, and otherwise transfer
-  your contribution in whole or in part, whether at a charge or at
-  no-charge;
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
 
-- You agree that neither of us have any duty to consult with, obtain the
-  consent of, pay or render accounts to the other for any use or
-  distribution of the material.
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
 
-With respect to the Licensee Modifications, you represent that:
-- it is an original work by you and that you can legally grant the
-  rights set out in these terms;
-- it does not to the best of your knowledge violate any third party's
-  copyrights, trademarks, patents or other intellectual property rights.
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
 
-8. Disclaimer of warranties
-The Licensed Software is licensed "as is," without any warranties
-whatsoever. Licensor expressly disclaims, and licensee expressly waives,
-all warranties, whether express or implied, including warranties of
-merchantability, fitness for a particular purpose, non-infringement,
-system integration, non-interference and accuracy of informational
-content. Licensor does not warrant that the licensed software will meet
-licensee's requirements or that the operation of the licensed software
-will be uninterrupted or error-free, or that errors will be corrected.
-The entire risk of the licensed software's quality and performance is
-with licensee.
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
 
-9. Indemnification
-Licensee agrees to indemnify and hold Licensor harmless against any
-damage or loss (including reasonable attorneys' fees) related to any
-claim based upon: (a) use of the Licensed Software in a manner
-prohibited under this license or in a manner for which the Licensed
-Software was not designed; (b) Licensee Modifications or changes made by
-Licensee to the Licensed Software (where use of unmodified Licensed
-Software would not infringe); or (c) changes made, or actions taken, by
-Licensor upon Licensee's direct instructions.
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
 
-10. Limitation of liability
-To the extent permitted by applicable law, licensor shall have no
-liability with respect to its obligations under this license or
-otherwise for direct, consequential, exemplary, special, indirect,
-incidental or punitive damages, including any lost profits or lost
-savings (whether resulting from impaired or lost data, software or
-computer failure or any other cause), even if it has been advised of the
-possibility of such damages.
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
 
-This limitation of liability applies to any default, including breach of
-contract, breach of warranty, negligence, misrepresentations and other
-torts. The parties agree that the remedies and limitations herein
-allocate the risks between the parties as authorized by applicable laws.
-The license fee (non) is set in reliance upon this allocation of risk
-and the exclusion of certain damages as set forth in this license.
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
 
-11. Miscellaneous
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
 
-11.1 Interpretation
-Failure by Licensor to exercise any right or remedy does not signify
-acceptance of the event giving rise to such right or remedy, or loss of
-such right. No claim arising out of this License may be brought by you
-more than one year after the cause of the claim arose.
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
 
-If any part of this license is held by a court of competent jurisdiction
-to be illegal or unenforceable, the validity or enforceability of the
-remainder of this License shall not be affected and such provision shall
-be deemed modified to the minimum extent necessary to make such
-provision consistent with applicable law. In its modified form, such
-provision shall be enforceable and enforced.
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
 
-11.2 Termination for patent action
-This license shall terminate automatically and you may no longer
-exercise any of the rights granted to you by this license as of the date
-you commence an action, including a cross-claim or counterclaim, against
-Ibexa, an Ibexa partner or other licensee of Ibexa software alleging that the
-Software infringes a patent.
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
 
-11.3 Assignment
-Without the prior written consent of Licensor, you may not assign,
-sublicense or otherwise transfer this license or its rights or
-obligations under this license to any person or party, whether by
-operation of law or otherwise. Any attempt by you to assign this license
-without Licensor's prior written consent is void and will terminate the
-license without further notice.
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
 
-11.4 Governing law
-This License shall be deemed to have been executed in Norway and shall
-be governed by the laws of Norway, without regard to any conflict of law
-provisions.
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
 
-11.5 Disputes and legal venue
-The parties shall first attempt to resolve any disputes, controversies
-or claims (collectively "Dispute") arising out of or relating to this
-license through amicable discussions and negotiations.
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
 
-If a Dispute cannot be resolved amicably between the parties, such
-Dispute shall be referred to Oslo City Court as mandatory legal venue.
-However, if you are located in a country that does not have a bilateral
-or multilateral ruling enforcement treaty with Norway, the Dispute shall
-be referred to and finally determined by arbitration administered by the
-World Intellectual Property Organization (WIPO) Arbitration and
-Mediation Centre in accordance with the WIPO Arbitration Rules.
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
 
-The place of arbitration shall be in Oslo, Norway. The arbitrator - of
-which there shall be only one - shall be bound by the provisions of this
-license and base the award on Norwegian substantive law and judicial
-precedent. The parties agree that the arbitrator shall have the power to
-decide all matters, including arbitrability, and to award any remedies,
-including attorneys' fees, costs and equitable relief, available under
-applicable law. Either party may enforce any judgment rendered by the
-arbitrator in any court of competent jurisdiction. The parties further
-agree and acknowledge that arbitration shall be the sole and final
-remedy for any dispute between the parties. All proceedings and
-documents shall remain strictly confidential.
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
 
-In no event shall the United Nations Convention on Contracts for the
-International Sale of Goods apply to, or govern, this License.
+                            NO WARRANTY
 
-11.6 Notices
-Any notice under this license shall be delivered and addressed to
-Licensee at the address provided to Licensor (or authorized
-representative) at the time of order, and to Licensor at
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
 
-Attn: Software Licensing Dept/CLA,
-Ibexa AS
-Solligata 2
-0254 Oslo
-Norway
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
 
-Notices are deemed received by any party: (a) on the day given, if
-personally delivered or if sent by confirmed facsimile transmission,
-receipt verified; (b) on the third day after deposit, if mailed by
-certified, first class, postage prepaid, return receipt requested mail,
-or by reputable, expedited overnight courier; or (c) on the fifth day
-after deposit, if sent by reputable, expedited international courier.
+                     END OF TERMS AND CONDITIONS
 
-Either party may change its address for notice purposes upon notice in
-accordance with this section.
+            How to Apply These Terms to Your New Programs
 
-11.7 Export law assurances
-Licensee is responsible for complying with any applicable local laws,
-including but not limited to export and import regulations.
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
 
-11.8 Entire agreement
-This license comprises the entire agreement, and supersedes and merges
-all prior proposals, understandings and agreements, oral and written,
-between the parties relating to the subject matter of this license.
-Licensor's acceptance of any document shall not be construed as an
-acceptance of provisions which are in any way in conflict or
-inconsistent with, or in addition to, this license, unless such terms
-are separately and specifically accepted in writing by an authorized
-officer of Licensor.
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
 
-11.9 Update of terms
-The Licensor may from time to time issue new versions of this license.
-Unless you within 30 days from when you were first made aware or should
-have become aware of the new license has not made reservations directed
-at Licensor in writing, such new version of the license shall be deemed
-as accepted by you.
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,20 @@
   ],
   "require": {
     "php": "^7.4 || ^8.0",
-    "ibexa/core": "^4.5.x-dev",
+    "ibexa/core": "~4.6.x-dev",
     "symfony/config": "^5.4",
     "symfony/dependency-injection": "^5.4",
     "symfony/event-dispatcher": "^5.4",
     "symfony/event-dispatcher-contracts": "^2.2",
     "symfony/http-foundation": "^5.4",
     "symfony/http-kernel": "^5.4",
-    "symfony/yaml": "^5.4"
+    "symfony/yaml": "^5.4",
+    "symfony/notifier": "^5.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^9",
     "ibexa/code-style": "^1.1",
+    "ibexa/doctrine-schema": "~4.6.x-dev",
     "phpstan/phpstan": "^1.10",
     "phpstan/phpstan-phpunit": "^1.3",
     "phpstan/phpstan-symfony": "^1.3",
@@ -57,7 +59,10 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-main": "4.5.x-dev"
+      "dev-main": "4.6.x-dev"
     }
+  },
+  "config": {
+    "allow-plugins": false
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ibexa/notifications",
-  "license": "GPL-2.0-only",
+  "license": "(GPL-2.0-only or proprietary)",
   "type": "ibexa-bundle",
   "keywords": [
     "ibexa-dxp"

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,9 @@
 {
   "name": "ibexa/notifications",
-  "license": "proprietary",
+  "license": "GPL-2.0-only",
   "type": "ibexa-bundle",
   "keywords": [
     "ibexa-dxp"
-  ],
-  "repositories": [
-    { "type": "composer", "url": "https://updates.ibexa.co" }
   ],
   "require": {
     "php": "^7.4 || ^8.0",

--- a/src/bundle/DependencyInjection/Configuration/Parser/NotificationsConfigParser.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/NotificationsConfigParser.php
@@ -64,7 +64,7 @@ final class NotificationsConfigParser extends AbstractParser
     /**
      * @param array<string, mixed> $config
      */
-    public function postMap(array $config, ContextualizerInterface $contextualizer)
+    public function postMap(array $config, ContextualizerInterface $contextualizer): void
     {
         foreach (self::MAPPED_SETTINGS as $setting) {
             $contextualizer->mapConfigArray(sprintf('notifications.%s', $setting), $config);

--- a/src/bundle/DependencyInjection/Configuration/Parser/NotificationsConfigParser.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/NotificationsConfigParser.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Notifications\DependencyInjection\Configuration\Parser;
+
+use Ibexa\Bundle\Core\DependencyInjection\Configuration\AbstractParser;
+use Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+final class NotificationsConfigParser extends AbstractParser
+{
+    public const MAPPED_SETTINGS = ['subscriptions'];
+
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
+    {
+        $nodeBuilder
+            ->arrayNode('notifications')
+                ->children()
+                    ->arrayNode('subscriptions')
+                        ->info('Mandatory system notifications. Users cannot opt-out from below subscriptions.')
+                        ->useAttributeAsKey('notification_type')
+                        ->arrayPrototype()
+                            ->children()
+                                ->arrayNode('channels')
+                                    ->cannotBeEmpty()
+                                    ->scalarPrototype()->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $scopeSettings
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        if (empty($scopeSettings['notifications'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['notifications'];
+
+        foreach (self::MAPPED_SETTINGS as $key) {
+            if (empty($settings[$key])) {
+                continue;
+            }
+
+            $contextualizer->setContextualParameter(
+                sprintf('notifications.%s', $key),
+                $currentScope,
+                $settings[$key]
+            );
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function postMap(array $config, ContextualizerInterface $contextualizer)
+    {
+        foreach (self::MAPPED_SETTINGS as $setting) {
+            $contextualizer->mapConfigArray(sprintf('notifications.%s', $setting), $config);
+        }
+    }
+}

--- a/src/bundle/IbexaNotificationsBundle.php
+++ b/src/bundle/IbexaNotificationsBundle.php
@@ -8,8 +8,17 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Notifications;
 
+use Ibexa\Bundle\Notifications\DependencyInjection\Configuration\Parser\NotificationsConfigParser;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class IbexaNotificationsBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        /** @var \Ibexa\Bundle\Core\DependencyInjection\IbexaCoreExtension $core */
+        $core = $container->getExtension('ibexa');
+
+        $core->addConfigParser(new NotificationsConfigParser());
+    }
 }

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -1,2 +1,3 @@
 imports:
-    - { resource: services/**/*.yaml }
+    - { resource: services/papi.yaml }
+    - { resource: services/subscription_resolver.yaml }

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -1,3 +1,4 @@
 imports:
+    - { resource: services/mappers.yaml }
     - { resource: services/papi.yaml }
     - { resource: services/subscription_resolver.yaml }

--- a/src/bundle/Resources/config/services/mappers.yaml
+++ b/src/bundle/Resources/config/services/mappers.yaml
@@ -1,0 +1,13 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Ibexa\Notifications\Mapper\NotificationMapper: ~
+
+    Ibexa\Notifications\Mapper\NotificationMapperInterface: '@Ibexa\Notifications\Mapper\NotificationMapper'
+
+    Ibexa\Notifications\Mapper\RecipientMapper: ~
+
+    Ibexa\Notifications\Mapper\RecipientMapperInterface: '@Ibexa\Notifications\Mapper\RecipientMapper'

--- a/src/bundle/Resources/config/services/papi.yaml
+++ b/src/bundle/Resources/config/services/papi.yaml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Ibexa\Notifications\Service\NotificationService: ~
+
+    Ibexa\Contracts\Notifications\Service\NotificationServiceInterface: '@Ibexa\Notifications\Service\NotificationService'

--- a/src/bundle/Resources/config/services/subscription_resolver.yaml
+++ b/src/bundle/Resources/config/services/subscription_resolver.yaml
@@ -1,0 +1,15 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Ibexa\Notifications\SubscriptionResolver\ConfigBasedSubscriptionResolver:
+        tags:
+            - ibexa.notifications.subscription_resolver
+
+    Ibexa\Notifications\SubscriptionResolver\ChainSubscriptionResolver:
+        arguments:
+            $resolvers: !tagged_iterator ibexa.notifications.subscription_resolver
+
+    Ibexa\Notifications\SubscriptionResolver\SubscriptionResolverInterface: '@Ibexa\Notifications\SubscriptionResolver\ChainSubscriptionResolver'

--- a/src/contracts/Service/NotificationServiceInterface.php
+++ b/src/contracts/Service/NotificationServiceInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Notifications\Service;
+
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+
+interface NotificationServiceInterface
+{
+    /**
+     * @param array<\Ibexa\Contracts\Notifications\Value\RecipientInterface> $recipients
+     */
+    public function send(NotificationInterface $notification, array $recipients = []): void;
+}

--- a/src/contracts/Value/Notification/SymfonyNotificationAdapter.php
+++ b/src/contracts/Value/Notification/SymfonyNotificationAdapter.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Notifications\Value\Notification;
+
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+use Symfony\Component\Notifier\Notification\Notification;
+
+final class SymfonyNotificationAdapter implements NotificationInterface
+{
+    private Notification $notification;
+
+    public function __construct(Notification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function getType(): string
+    {
+        return get_class($this->notification);
+    }
+
+    public function getNotification(): Notification
+    {
+        return $this->notification;
+    }
+}

--- a/src/contracts/Value/NotificationInterface.php
+++ b/src/contracts/Value/NotificationInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Notifications\Value;
+
+interface NotificationInterface
+{
+    public function getType(): string;
+}

--- a/src/contracts/Value/Recipent/SymfonyRecipientAdapter.php
+++ b/src/contracts/Value/Recipent/SymfonyRecipientAdapter.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Notifications\Value\Recipent;
+
+use Ibexa\Contracts\Notifications\Value\RecipientInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
+
+final class SymfonyRecipientAdapter implements RecipientInterface
+{
+    private Recipient $recipient;
+
+    public function __construct(Recipient $recipient)
+    {
+        $this->recipient = $recipient;
+    }
+
+    public function getMail(): string
+    {
+        return $this->recipient->getEmail();
+    }
+
+    public function getPhone(): string
+    {
+        return $this->recipient->getPhone();
+    }
+
+    public function getRecipient(): Recipient
+    {
+        return $this->recipient;
+    }
+}

--- a/src/contracts/Value/Recipent/SymfonyRecipientAdapter.php
+++ b/src/contracts/Value/Recipent/SymfonyRecipientAdapter.php
@@ -9,28 +9,53 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Notifications\Value\Recipent;
 
 use Ibexa\Contracts\Notifications\Value\RecipientInterface;
-use Symfony\Component\Notifier\Recipient\Recipient;
+use Ibexa\Core\Base\Exceptions\BadStateException;
+use Symfony\Component\Notifier\Recipient\EmailRecipientInterface;
+use Symfony\Component\Notifier\Recipient\RecipientInterface as SymfonyRecipentInterface;
+use Symfony\Component\Notifier\Recipient\SmsRecipientInterface;
 
 final class SymfonyRecipientAdapter implements RecipientInterface
 {
-    private Recipient $recipient;
+    private SymfonyRecipentInterface $recipient;
 
-    public function __construct(Recipient $recipient)
+    public function __construct(SymfonyRecipentInterface $recipient)
     {
         $this->recipient = $recipient;
     }
 
     public function getMail(): string
     {
+        if (!$this->recipient instanceof EmailRecipientInterface) {
+            throw new BadStateException(
+                '$recipient',
+                sprintf(
+                    'Internal %s instance does not implement %s',
+                    SymfonyRecipentInterface::class,
+                    EmailRecipientInterface::class,
+                ),
+            );
+        }
+
         return $this->recipient->getEmail();
     }
 
     public function getPhone(): string
     {
+        if (!$this->recipient instanceof SmsRecipientInterface) {
+            throw new BadStateException(
+                '$recipient',
+                sprintf(
+                    'Internal %s instance does not implement %s',
+                    SymfonyRecipentInterface::class,
+                    SmsRecipientInterface::class,
+                ),
+            );
+        }
+
         return $this->recipient->getPhone();
     }
 
-    public function getRecipient(): Recipient
+    public function getRecipient(): SymfonyRecipentInterface
     {
         return $this->recipient;
     }

--- a/src/contracts/Value/RecipientInterface.php
+++ b/src/contracts/Value/RecipientInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Notifications\Value;
+
+interface RecipientInterface
+{
+    public function getMail(): string;
+
+    public function getPhone(): string;
+}

--- a/src/lib/Mapper/NotificationMapper.php
+++ b/src/lib/Mapper/NotificationMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\Mapper;
+
+use Ibexa\Contracts\Notifications\Value\Notification\SymfonyNotificationAdapter;
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
+use Symfony\Component\Notifier\Notification\Notification;
+
+final class NotificationMapper implements NotificationMapperInterface
+{
+    public function mapToSymfonyNotification(NotificationInterface $notification): Notification
+    {
+        if (!$notification instanceof SymfonyNotificationAdapter) {
+            throw new InvalidArgumentException(
+                '$notification',
+                sprintf('This mapper only supports %s objects', SymfonyNotificationAdapter::class),
+            );
+        }
+
+        return $notification->getNotification();
+    }
+}

--- a/src/lib/Mapper/NotificationMapperInterface.php
+++ b/src/lib/Mapper/NotificationMapperInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\Mapper;
+
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+use Symfony\Component\Notifier\Notification\Notification;
+
+interface NotificationMapperInterface
+{
+    /**
+     * Produces Symfony Notifier's compatible Notification object.
+     *
+     * @throws \Ibexa\Contracts\Core\Exception\InvalidArgumentException
+     */
+    public function mapToSymfonyNotification(NotificationInterface $notification): Notification;
+}

--- a/src/lib/Mapper/RecipientMapper.php
+++ b/src/lib/Mapper/RecipientMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\Mapper;
+
+use Ibexa\Contracts\Notifications\Value\Recipent\SymfonyRecipientAdapter;
+use Ibexa\Contracts\Notifications\Value\RecipientInterface;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
+use Symfony\Component\Notifier\Recipient\RecipientInterface as SymfonyRecipientInterface;
+
+final class RecipientMapper implements RecipientMapperInterface
+{
+    public function mapToSymfonyRecipient(RecipientInterface $recipient): SymfonyRecipientInterface
+    {
+        if (!$recipient instanceof SymfonyRecipientAdapter) {
+            throw new InvalidArgumentException(
+                '$recipient',
+                sprintf('This mapper only supports %s objects', SymfonyRecipientAdapter::class),
+            );
+        }
+
+        return $recipient->getRecipient();
+    }
+}

--- a/src/lib/Mapper/RecipientMapperInterface.php
+++ b/src/lib/Mapper/RecipientMapperInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\Mapper;
+
+use Ibexa\Contracts\Notifications\Value\RecipientInterface;
+use Symfony\Component\Notifier\Recipient\RecipientInterface as SymfonyRecipientInterface;
+
+interface RecipientMapperInterface
+{
+    /**
+     * Produces Symfony Notifier's compatible RecipientInterface object.
+     *
+     * @throws \Ibexa\Contracts\Core\Exception\InvalidArgumentException
+     */
+    public function mapToSymfonyRecipient(RecipientInterface $recipient): SymfonyRecipientInterface;
+}

--- a/src/lib/Service/NotificationService.php
+++ b/src/lib/Service/NotificationService.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\Service;
+
+use Ibexa\Contracts\Notifications\Service\NotificationServiceInterface;
+use Ibexa\Contracts\Notifications\Value\Notification\SymfonyNotificationAdapter;
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+use Ibexa\Contracts\Notifications\Value\Recipent\SymfonyRecipientAdapter;
+use Ibexa\Notifications\SubscriptionResolver\SubscriptionResolverInterface;
+use Ibexa\Notifications\Value\ChannelSubscription;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
+
+final class NotificationService implements NotificationServiceInterface
+{
+    private NotifierInterface $notifier;
+
+    private SubscriptionResolverInterface $subscriptionResolver;
+
+    public function __construct(
+        NotifierInterface $notifier,
+        SubscriptionResolverInterface $subscriptionResolver
+    ) {
+        $this->notifier = $notifier;
+        $this->subscriptionResolver = $subscriptionResolver;
+    }
+
+    /**
+     * @param array<\Ibexa\Contracts\Notifications\Value\RecipientInterface> $recipients
+     */
+    public function send(NotificationInterface $notification, array $recipients = []): void
+    {
+        $channels = array_map(
+            static fn (ChannelSubscription $channelSubscription): string => $channelSubscription->getChannel(),
+            array_filter(iterator_to_array($this->subscriptionResolver->resolve($notification)))
+        );
+
+        if (empty($channels)) {
+            return;
+        }
+
+        $symfonyRecipients = $this->getSymfonyRecipients($recipients);
+        $symfonyNotification = $notification instanceof SymfonyNotificationAdapter
+            ? $notification->getNotification()
+            : new Notification();
+
+        $symfonyNotification->channels($channels);
+
+        $this->notifier->send(
+            $symfonyNotification,
+            ...$symfonyRecipients,
+        );
+    }
+
+    /**
+     * @param array<\Ibexa\Contracts\Notifications\Value\RecipientInterface> $recipients
+     *
+     * @return array<\Symfony\Component\Notifier\Recipient\RecipientInterface>
+     */
+    private function getSymfonyRecipients(array $recipients): array
+    {
+        $symfonyRecipients = [];
+        foreach ($recipients as $recipient) {
+            $symfonyRecipients[] = $recipient instanceof SymfonyRecipientAdapter
+                ? $recipient->getRecipient()
+                : new Recipient(
+                    $recipient->getMail(),
+                    $recipient->getPhone(),
+                );
+        }
+
+        return $symfonyRecipients;
+    }
+}

--- a/src/lib/SubscriptionResolver/ChainSubscriptionResolver.php
+++ b/src/lib/SubscriptionResolver/ChainSubscriptionResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\SubscriptionResolver;
+
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+
+final class ChainSubscriptionResolver implements SubscriptionResolverInterface
+{
+    /** @var iterable<\Ibexa\Notifications\SubscriptionResolver\SubscriptionResolverInterface> */
+    private iterable $resolvers;
+
+    /**
+     * @param iterable<\Ibexa\Notifications\SubscriptionResolver\SubscriptionResolverInterface> $resolvers
+     */
+    public function __construct(iterable $resolvers)
+    {
+        $this->resolvers = $resolvers;
+    }
+
+    public function resolve(NotificationInterface $notification, array $context = []): iterable
+    {
+        foreach ($this->resolvers as $resolver) {
+            $channelSubscriptions = $resolver->resolve($notification, $context);
+            foreach ($channelSubscriptions as $channelSubscription) {
+                if (null === $channelSubscription) {
+                    continue;
+                }
+
+                yield $channelSubscription;
+            }
+        }
+    }
+}

--- a/src/lib/SubscriptionResolver/ConfigBasedSubscriptionResolver.php
+++ b/src/lib/SubscriptionResolver/ConfigBasedSubscriptionResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\SubscriptionResolver;
+
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+use Ibexa\Notifications\Value\ChannelSubscription;
+
+final class ConfigBasedSubscriptionResolver implements SubscriptionResolverInterface
+{
+    private ConfigResolverInterface $configResolver;
+
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    public function resolve(NotificationInterface $notification, array $context = []): iterable
+    {
+        $config = $this->configResolver->getParameter('notifications.subscriptions');
+        $notificationType = $notification->getType();
+
+        if (!array_key_exists($notificationType, $config)) {
+            yield;
+        }
+
+        foreach ($config[$notificationType]['channels'] as $channel) {
+            yield new ChannelSubscription($notificationType, $channel);
+        }
+    }
+}

--- a/src/lib/SubscriptionResolver/SubscriptionResolverInterface.php
+++ b/src/lib/SubscriptionResolver/SubscriptionResolverInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\SubscriptionResolver;
+
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+
+interface SubscriptionResolverInterface
+{
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @return \Iterator<\Ibexa\Notifications\Value\ChannelSubscription|null>
+     */
+    public function resolve(NotificationInterface $notification, array $context = []): iterable;
+}

--- a/src/lib/Value/ChannelSubscription.php
+++ b/src/lib/Value/ChannelSubscription.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Notifications\Value;
+
+final class ChannelSubscription
+{
+    private string $notificationType;
+
+    private string $channel;
+
+    public function __construct(string $notificationType, string $channel)
+    {
+        $this->notificationType = $notificationType;
+        $this->channel = $channel;
+    }
+
+    public function getNotificationType(): string
+    {
+        return $this->notificationType;
+    }
+
+    public function getChannel(): string
+    {
+        return $this->channel;
+    }
+}


### PR DESCRIPTION
| Question                       | Answer                                                |
|--------------------------------|-------------------------------------------------------|
| **JIRA issue**                 | [IBX-7057](https://issues.ibexa.co/browse/IBX-7057) |
| **Type**                       | feature                              |
| **Target eZ Platform version** | `v4.6`                |
| **BC breaks**                  |no                                                |
| **Doc needed**                 | yes                                                |


# `NotificationService`
It's the core of this feature. It exposes PHP API for sending system and user notifications. It uses `symfony/notifier` internally but I provided our own abstraction just in case. It offers great flexibility on how Notifications can be delivered. We can route all Admin UI flash messages via specific Notifications API channel and make them appear in the browser OR let users decide if they want specific Admin notification to be also delivered to Slack or e-mail.

Symfony Notifier can also take advantage of the Message Bus and we can send notifications asynchronously, unblocking requests from dealing with SMTP servers or APIs.

## `ChannelSubscription` and `SubscriptionResolver`
Since we want to offer flexibility and we have a few notification channels already, I made a simple configuration to decide which Notification goes where. Configuration should be only used for system notifications or things from which the user can't opt out. I assume in the future we'll let users subscribe to only specific types of notifications. This is where `ChainSubscriptionResolver` comes into place - it can resolve subscriptions from multiple resolvers. I have different data sources in mind - i.e. there will be a new Resolver reading subscriptions from User Preferences.

## Example configuration

```yaml
ibexa:
    system:
        default:
            notifications:
                subscriptions:
                    Ibexa\Notifications\Value\Notification\OrderConfirmationNotification:
                        channels:
                            - actito
```

The configuration is siteaccess aware and single notification can be routed to multiple channels.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
