### PR TITLE
IBX-7782: Removed symfony/event-dispatcher-contracts direct dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "symfony/config": "^5.4",
     "symfony/dependency-injection": "^5.4",
     "symfony/event-dispatcher": "^5.4",
-    "symfony/event-dispatcher-contracts": "^2.2",
     "symfony/http-foundation": "^5.4",
     "symfony/http-kernel": "^5.4",
     "symfony/yaml": "^5.4",


### PR DESCRIPTION
| Question                       | Answer                                                |
|--------------------------------|-------------------------------------------------------|
| **JIRA issue**                 | [IBX-7782](https://issues.ibexa.co/browse/IBX-7782) |
| **Type**                       | bug                                               | 
| **Target Ibexa version**       | `v4.6`                                                |
| **BC breaks**                  | no                                                    |
| **Doc needed**                 | no                                                    |

It is not necessary for us to rely on `symfony/event-dispatcher-contracts` directly, as this dependency is declared by `symfony/event-dispatcher` itself.

Since we are not agnostic to event dispatcher implementation, we should not declare this dependency ourselves.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
