### PR TITLE
[BC BREAK] IBX-7946: Renamed main SA aware config node from notifications to notifier

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/NotificationsConfigParser.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/NotificationsConfigParser.php
@@ -18,8 +18,14 @@ final class NotificationsConfigParser extends AbstractParser
 
     public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
+        /*
+         * Node name has been changed from "notifications" to "notifier" due to
+         * collision with Admin UI notifications parser.
+         *
+         * TODO: Change the name back to "notifications" in the next major version.
+         */
         $nodeBuilder
-            ->arrayNode('notifications')
+            ->arrayNode('notifier')
                 ->children()
                     ->arrayNode('subscriptions')
                         ->info('Mandatory system notifications. Users cannot opt-out from below subscriptions.')
@@ -42,11 +48,11 @@ final class NotificationsConfigParser extends AbstractParser
      */
     public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
-        if (empty($scopeSettings['notifications'])) {
+        if (empty($scopeSettings['notifier'])) {
             return;
         }
 
-        $settings = $scopeSettings['notifications'];
+        $settings = $scopeSettings['notifier'];
 
         foreach (self::MAPPED_SETTINGS as $key) {
             if (!isset($settings[$key])) {

--- a/src/bundle/Resources/config/prepend.yaml
+++ b/src/bundle/Resources/config/prepend.yaml
@@ -3,5 +3,5 @@
 ibexa:
     system:
         default:
-            notifications:
+            notifier:
                 subscriptions: []


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-7946](https://issues.ibexa.co/browse/IBX-7946) |
| **Type**                 | bug                             |
| **Target Ibexa version** | `v4.6`                                              |
| **BC breaks**            | yes/no                                              |

Related PRs:
- https://github.com/ibexa/shipping/pull/69
- https://github.com/ibexa/payment/pull/141
- https://github.com/ibexa/order-management/pull/116
- https://github.com/ibexa/connector-actito/pull/11

When implementing this package I overlooked the fact `notifications` node is already defined in Admin UI. We have name collision here and in result you can't override notification settings from Admin UI.

I was considering different solutions and opted for the simplest one - just rename the node and avoid doing hacky things to keep old configuration working in both `ibexa/admin-ui` and `ibexa/notifications`. It's a BC break but no other solution I've come up with was 100% BC safe and it always ended up being a maintenance mess. `ibexa/notifications` adoption is still very low as it's early in 4.6 life cycle and the package was never properly documented since it's not widely used in Ibexa DXP yet.

## How to deal with introduced BC break
If you are already using this package (`ibexa/notifications`) and used SiteAccess aware configuration to change Notification subscriptions your configuration will no longer work and it'll fail early in container compilation process. You have to manually change your configuration by using new node name `notifier` instead of the old one `notifications`.

```yaml
ibexa:
    system:
        my_siteacces_name:
            notifications:
                subscriptions:
                    Ibexa\Contracts\Shipping\Notification\ShipmentStatusChange:
                        channels:
                            - sms
```

becomes:

```yaml
ibexa:
    system:
        my_siteacces_name:
            notifier: # change from notifications to notifier
                subscriptions:
                    Ibexa\Contracts\Shipping\Notification\ShipmentStatusChange:
                        channels:
                            - sms
```

#### Documentation:
Document the BC break for 4.6.3 release as described above.