### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -14,9 +14,9 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '8.1'
+                    - '8.3'
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -26,9 +26,9 @@ jobs:
                     extensions: 'pdo_sqlite, gd'
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
-                    dependency-versions: "highest"
+                    dependency-versions: highest
 
             -   name: Run code style check
                 run: composer run-script check-cs -- --format=checkstyle | cs2pr
@@ -37,7 +37,7 @@ jobs:
         name: Deptrac
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
             -   name: Deptrac
                 uses: smoench/deptrac-action@master
 
@@ -50,12 +50,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.1'
-                    - '8.2'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -65,10 +63,9 @@ jobs:
                     extensions: pdo_sqlite, gd
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
-                    dependency-versions: "highest"
-                    composer-options: "--prefer-dist --no-progress --no-suggest"
+                    dependency-versions: highest
 
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -103,12 +100,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.1'
-                    - '8.2'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -118,9 +113,9 @@ jobs:
                     extensions: pdo_pgsql, gd
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
-                    dependency-versions: "highest"
+                    dependency-versions: highest
 
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -156,12 +151,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.1'
-                    - '8.2'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -171,9 +164,9 @@ jobs:
                     extensions: pdo_mysql, gd, redis
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
-                    dependency-versions: "highest"
+                    dependency-versions: highest
 
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -16,12 +16,12 @@ on:
 jobs:
     frontend-test:
         name: Frontend build test
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 5
 
         steps:
-            -   uses: actions/checkout@v2
-            -   uses: actions/setup-node@v2
+            -   uses: actions/checkout@v4
+            -   uses: actions/setup-node@v4
                 with:
                     node-version: '18'
             -   run: yarn install

--- a/composer.json
+++ b/composer.json
@@ -6,23 +6,23 @@
         "ibexa-dxp"
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "ibexa/core": "~5.0.x-dev",
         "symfony/config": "^5.4",
         "symfony/dependency-injection": "^5.4",
         "symfony/event-dispatcher": "^5.4",
         "symfony/http-foundation": "^5.4",
         "symfony/http-kernel": "^5.4",
-        "symfony/yaml": "^5.4",
-        "symfony/notifier": "^5.4"
+        "symfony/notifier": "^5.4",
+        "symfony/yaml": "^5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
         "ibexa/code-style": "^1.1",
         "ibexa/doctrine-schema": "~5.0.x-dev",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",
+        "phpunit/phpunit": "^9",
         "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
     },
     "autoload": {
@@ -59,6 +59,7 @@
         }
     },
     "config": {
-        "allow-plugins": false
+        "allow-plugins": false,
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
