### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
     "require": {
         "php": " >=8.3",
         "ibexa/core": "~5.0.x-dev",
-        "symfony/config": "^5.4",
-        "symfony/dependency-injection": "^5.4",
-        "symfony/event-dispatcher": "^5.4",
-        "symfony/http-foundation": "^5.4",
-        "symfony/http-kernel": "^5.4",
-        "symfony/notifier": "^5.4",
-        "symfony/yaml": "^5.4"
+        "symfony/config": "^6.4",
+        "symfony/dependency-injection": "^6.4",
+        "symfony/event-dispatcher": "^6.4",
+        "symfony/http-foundation": "^6.4",
+        "symfony/http-kernel": "^6.4",
+        "symfony/notifier": "^6.4",
+        "symfony/yaml": "^6.4"
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",

--- a/src/bundle/DependencyInjection/Configuration/Parser/NotificationsConfigParser.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/NotificationsConfigParser.php
@@ -14,7 +14,8 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 final class NotificationsConfigParser extends AbstractParser
 {
-    public const MAPPED_SETTINGS = ['subscriptions'];
+    /** @phpstan-var list<string> */
+    public const array MAPPED_SETTINGS = ['subscriptions'];
 
     public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {

--- a/src/bundle/DependencyInjection/IbexaNotificationsExtension.php
+++ b/src/bundle/DependencyInjection/IbexaNotificationsExtension.php
@@ -20,6 +20,8 @@ final class IbexaNotificationsExtension extends Extension implements PrependExte
 {
     /**
      * @param array<string, mixed> $configs
+     *
+     * @throws \Exception
      */
     public function load(array $configs, ContainerBuilder $container): void
     {


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready
> - [x] :exclamation:  **Remove TMP commits before merge** :exclamation:

| :ticket: Issue | IBX-8470 |
|----------------|-----------|


#### Related PRs:
- https://github.com/ibexa/core/pull/447
- https://github.com/ibexa/doctrine-schema/pull/27

#### Description:

This PR bumps Symfony to v6 with some codebase upgrades.

Key changes:

- [x] Bumped Symfony packages requirements to ^6.4
- [x] Improved NotificationsConfigParser code quality
- [x] Improved IbexaNotificationsExtension code quality

#### QA:

Sanities in the form of regression tests.

#### Documentation:

No documentation required.