### PR TITLE
Allowed support for native Symfony notifications in NotificationService::send

### DIFF
--- a/src/lib/Mapper/NotificationMapper.php
+++ b/src/lib/Mapper/NotificationMapper.php
@@ -17,13 +17,18 @@ final class NotificationMapper implements NotificationMapperInterface
 {
     public function mapToSymfonyNotification(NotificationInterface $notification): Notification
     {
-        if (!$notification instanceof SymfonyNotificationAdapter) {
-            throw new InvalidArgumentException(
-                '$notification',
-                sprintf('This mapper only supports %s objects', SymfonyNotificationAdapter::class),
-            );
+        if ($notification instanceof Notification) {
+            // Notification is already Symfony compatible
+            return $notification;
         }
 
-        return $notification->getNotification();
+        if ($notification instanceof SymfonyNotificationAdapter) {
+            return $notification->getNotification();
+        }
+
+        throw new InvalidArgumentException(
+            '$notification',
+            sprintf('This mapper only supports %s or %s objects', Notification::class, SymfonyNotificationAdapter::class),
+        );
     }
 }

--- a/tests/lib/Mapper/NativeNotification.php
+++ b/tests/lib/Mapper/NativeNotification.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Notifications\Mapper;
+
+use Ibexa\Contracts\Notifications\Value\NotificationInterface;
+use Symfony\Component\Notifier\Notification\Notification;
+
+/**
+ * Example notification class for testing purposes.
+ *
+ * @internal
+ */
+final class NativeNotification extends Notification implements NotificationInterface
+{
+    public function getType(): string
+    {
+        return self::class;
+    }
+}

--- a/tests/lib/Mapper/NotificationMapperTest.php
+++ b/tests/lib/Mapper/NotificationMapperTest.php
@@ -32,7 +32,7 @@ final class NotificationMapperTest extends TestCase
             new SymfonyNotificationAdapter($notification)
         );
 
-        $this->assertSame($notification, $symfonyNotification);
+        self::assertSame($notification, $symfonyNotification);
     }
 
     public function testMapToSymfonyNotificationForNativeNotification(): void
@@ -41,7 +41,7 @@ final class NotificationMapperTest extends TestCase
 
         $symfonyNotification = $this->mapper->mapToSymfonyNotification($notification);
 
-        $this->assertSame($notification, $symfonyNotification);
+        self::assertSame($notification, $symfonyNotification);
     }
 
     public function testMapToSymfonyNotificationThrowsExceptionOnInvalidNotification(): void

--- a/tests/lib/Mapper/NotificationMapperTest.php
+++ b/tests/lib/Mapper/NotificationMapperTest.php
@@ -24,13 +24,22 @@ final class NotificationMapperTest extends TestCase
         $this->mapper = new NotificationMapper();
     }
 
-    public function testMapToSymfonyNotification(): void
+    public function testMapToSymfonyNotificationForSymfonyAdapter(): void
     {
         $notification = $this->createMock(Notification::class);
 
         $symfonyNotification = $this->mapper->mapToSymfonyNotification(
             new SymfonyNotificationAdapter($notification)
         );
+
+        $this->assertSame($notification, $symfonyNotification);
+    }
+
+    public function testMapToSymfonyNotificationForNativeNotification(): void
+    {
+        $notification = new NativeNotification();
+
+        $symfonyNotification = $this->mapper->mapToSymfonyNotification($notification);
 
         $this->assertSame($notification, $symfonyNotification);
     }


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Added support for `Symfony\Component\Notifier\Notification\Notification` which in the same time implements `\Ibexa\Contracts\Notifications\Value\NotificationInterface` in `Ibexa\Notifications\Mapper\NotificationMapper`. 

#### For QA:
N/A

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
