### PR TITLE
IBX-9060: Implemented support for typed system notifications and dynamic template extension

### DIFF
--- a/src/bundle/Resources/translations/ibexa_notifications.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_notifications.en.xliff
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="b03e8123321d8b69e3e3d209bb58a0c0d3e5bf7f" resname="notifications.notification.system.label">
+        <source>System notification</source>
+        <target state="new">System notification</target>
+        <note>key: notifications.notification.system.label</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/views/themes/admin/notification/system_notification.html.twig
+++ b/src/bundle/Resources/views/themes/admin/notification/system_notification.html.twig
@@ -18,9 +18,7 @@
 {% endblock %}
 
 {% block message %}
-    {% embed '@ibexadesign/ui/component/table/table_body_cell.html.twig' with { class: 'ibexa-notifications-modal__description' } %}
-        {% block content %}
-            <p class="description__text">{{ content|default('') }}</p>
-        {% endblock %}
-    {% endembed %}
+    {% block content %}
+        <p title="{{ content|default('') }}" class="description__text">{{ content|default('') }}</p>
+    {% endblock %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/notification/system_notification.html.twig
+++ b/src/bundle/Resources/views/themes/admin/notification/system_notification.html.twig
@@ -1,4 +1,4 @@
-{% extends '@ibexadesign/account/notifications/list_item.html.twig' %}
+{% extends template_to_extend %}
 
 {% trans_default_domain 'ibexa_notification' %}
 

--- a/src/bundle/Resources/views/themes/admin/notification/system_notification.html.twig
+++ b/src/bundle/Resources/views/themes/admin/notification/system_notification.html.twig
@@ -19,6 +19,6 @@
 
 {% block message %}
     {% block content %}
-        <p title="{{ content|default('') }}" class="description__text">{{ content|default('') }}</p>
+        <p title="{{ content|default('') }}" class="description__text{% if content|length > 100 %} description__text--ellipsis{% endif %}">{{ content|default('') }}</p>
     {% endblock %}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/admin/notification/system_notification.html.twig
+++ b/src/bundle/Resources/views/themes/admin/notification/system_notification.html.twig
@@ -1,4 +1,4 @@
-{% extends template_to_extend %}
+{% extends base_template %}
 
 {% trans_default_domain 'ibexa_notification' %}
 

--- a/src/lib/SystemNotification/SystemNotificationRenderer.php
+++ b/src/lib/SystemNotification/SystemNotificationRenderer.php
@@ -50,7 +50,7 @@ final class SystemNotificationRenderer implements NotificationRenderer, TypedNot
         $templateToExtend = '@ibexadesign/account/notifications/list_item.html.twig';
 
         $currentRequest = $this->requestStack->getCurrentRequest();
-        if ($currentRequest && $currentRequest->attributes->getBoolean('render_all')) {
+        if ($currentRequest !== null && $currentRequest->attributes->getBoolean('render_all')) {
             $templateToExtend = '@ibexadesign/account/notifications/list_item_all.html.twig';
         }
 

--- a/src/lib/SystemNotification/SystemNotificationRenderer.php
+++ b/src/lib/SystemNotification/SystemNotificationRenderer.php
@@ -47,11 +47,11 @@ final class SystemNotificationRenderer implements NotificationRenderer, TypedNot
 
     public function render(Notification $notification): string
     {
-        $templateToExtend = '@ibexadesign/account/notifications/list_item.html.twig';
+        $baseTemplate = '@ibexadesign/account/notifications/list_item.html.twig';
 
         $currentRequest = $this->requestStack->getCurrentRequest();
         if ($currentRequest !== null && $currentRequest->attributes->getBoolean('render_all')) {
-            $templateToExtend = '@ibexadesign/account/notifications/list_item_all.html.twig';
+            $baseTemplate = '@ibexadesign/account/notifications/list_item_all.html.twig';
         }
 
         return $this->twig->render(
@@ -62,7 +62,7 @@ final class SystemNotificationRenderer implements NotificationRenderer, TypedNot
                 'content' => $notification->data[self::KEY_CONTENT] ?? null,
                 'subject' => $notification->data[self::KEY_SUBJECT] ?? null,
                 'created_at' => $notification->created,
-                'template_to_extend' => $templateToExtend,
+                'base_template' => $baseTemplate,
             ]
         );
     }
@@ -81,11 +81,11 @@ final class SystemNotificationRenderer implements NotificationRenderer, TypedNot
 
     public function getTypeLabel(): string
     {
-        return /** @Desc("System notification") */
-            $this->translator->trans(
-                'notifications.notification.system.label',
-                [],
-                'ibexa_notifications'
-            );
+        return $this->translator->trans(
+            /** @Desc("System notification") */
+            'notifications.notification.system.label',
+            [],
+            'ibexa_notifications'
+        );
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-9060 |
|----------------|----------|

#### Description:
- Introduced `getTypeLabel()` returning translated "System notification" label.
- Added logic to switch notification template between  
  `list_item.html.twig` and `list_item_all.html.twig` based on `render_all` request attribute.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
